### PR TITLE
add friendly error messages while git excludesFile is null.

### DIFF
--- a/src/Blitz.Files/IgnorePath.cs
+++ b/src/Blitz.Files/IgnorePath.cs
@@ -24,7 +24,8 @@ public class IgnorePath
         _ignore = new Ignore();
         if (!File.Exists(ignoreFile))
         {
-            throw new FileNotFoundException(ignoreFile);
+			string friendlyErrorMessages = "git config --global core.excludesFile incorrect with \'" + ignoreFile + "\'";
+            throw new FileNotFoundException(friendlyErrorMessages);
         }
 
         IgnoreFileName = ignoreFile;


### PR DESCRIPTION
When I updated to the new version, I found that the search functional failure.

After investigation, the trigger is due to my local git configuration of **excludesFile** is null. 

But the error message like `Exception:` is just simple. It is impossible to know the specific reason. I modified the exception message to provide more clearer error information.

In addition, should the external errors not cause the function to malfunction?